### PR TITLE
Fix building under Ubuntu 16.04

### DIFF
--- a/modules/datasets/CMakeLists.txt
+++ b/modules/datasets/CMakeLists.txt
@@ -45,6 +45,9 @@ if(USE_BSDS500_BENCHMARK)
     target_link_libraries(${LITIV_CURRENT_PROJECT_NAME} BSDS500)
 endif()
 target_link_litiv_dependencies(${LITIV_CURRENT_PROJECT_NAME})
+if(UNIX)
+    target_link_libraries(${LITIV_CURRENT_PROJECT_NAME} pthread)
+endif()
 target_include_directories(${LITIV_CURRENT_PROJECT_NAME}
     PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/>"
     PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>"


### PR DESCRIPTION
When building the library under Ubuntu 16.04 I had the following error:
```
/usr/bin/ld: ../../lib/liblitiv_datasets.a(utils.cpp.o): undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
```
This patch fixes the build for me.