### PR TITLE
fix build litiv/3rdparty/ofdis/include/litiv/3rdparty/ofdis/ofdis.hpp…

### DIFF
--- a/3rdparty/ofdis/include/litiv/3rdparty/ofdis/ofdis.hpp
+++ b/3rdparty/ofdis/include/litiv/3rdparty/ofdis/ofdis.hpp
@@ -21,7 +21,7 @@ namespace ofdis {
     private:
         void setOpPointParams(const cv::Size& oImageSize);
         template<FlowInputType eInput, FlowOutputType eOutput>
-        friend void computeFlow(const cv::Mat&,const cv::Mat&,cv::Mat&,FlowParams=FlowParams());
+        friend void computeFlow(const cv::Mat&,const cv::Mat&,cv::Mat&,FlowParams);
     };
 
     /// ofdis algorithm interface, with all specialized input/output combos pre-instantiated


### PR DESCRIPTION
Hi,

This pull request is fixing compilation that fails with error:  
```
Scanning dependencies of target litiv_3rdparty_ofdis
[  7%] Building CXX object 3rdparty/ofdis/CMakeFiles/litiv_3rdparty_ofdis.dir/src/ofdis.cpp.o
In file included from litiv/3rdparty/ofdis/src/ofdis.cpp:5:
litiv/3rdparty/ofdis/include/litiv/3rdparty/ofdis/ofdis.hpp:24:21: error: friend declaration of ‘void computeFlow(const cv::Mat&, const cv::Mat&, cv::Mat&, ofdis::FlowParams)’ specifies default arguments and isn’t a definition [-fpermissive]
   24 |         friend void computeFlow(const cv::Mat&,const cv::Mat&,cv::Mat&,FlowParams=FlowParams());
      |                     ^~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
```
